### PR TITLE
Upgrade ubuntu-20.04 to ubuntu-24.04 runner version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -106,13 +106,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-24.04, ubuntu-22.04]
         sslpkg: [libmbedtls-dev]
         ssllib: [mbedtls]
         libname: [mbed TLS]
 
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             sslpkg: "libssl-dev"
             libname: OpenSSL 1.1.1
             ssllib: openssl
@@ -122,28 +122,28 @@ jobs:
             ssllib: openssl
             pkcs11pkg: "libpkcs11-helper1-dev softhsm2 gnutls-bin"
             extraconf: --enable-pkcs11
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             sslpkg: "libssl-dev"
             libname: OpenSSL 1.1.1
             ssllib: openssl
             pkcs11pkg: "libpkcs11-helper1-dev softhsm2 gnutls-bin"
             extraconf: "--enable-iproute2 --enable-pkcs11"
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             sslpkg: "libssl-dev"
             libname: OpenSSL 1.1.1
             ssllib: openssl
             extraconf: "--enable-async-push"
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             sslpkg: "libssl-dev"
             libname: OpenSSL 1.1.1
             ssllib: openssl
             extraconf: "--disable-management"
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             sslpkg: "libssl-dev"
             libname: OpenSSL 1.1.1
             ssllib: openssl
             extraconf: "--enable-small"
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             sslpkg: "libssl-dev"
             libname: OpenSSL 1.1.1
             ssllib: openssl
@@ -173,7 +173,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-24.04]
         ssllib: [mbedtls, openssl]
 
     name: "clang-asan - ${{matrix.os}} - ${{matrix.ssllib}}"


### PR DESCRIPTION
# Description

Shortcut

- Story: https://app.shortcut.com/cartoteam/story/470573
- Autolink: [sc-470573]

In order to avoid deprecation and our CI/CD not running because we are using runners deprecated upgrade to the latest version available.